### PR TITLE
created the event detail view and url route -- solved issue #368

### DIFF
--- a/calendar_backend/calendarapp/urls.py
+++ b/calendar_backend/calendarapp/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('create-event/', CreateEventView.as_view(), name='create_event'),
     path('create-reminder/', CreateReminderView.as_view(), name='create-reminder'),
     path('event-list/', event_list, name="event_lists"),
+    path('event-detail/<str:id>/', event_detail_view),
     path('sidebar/', side_bar_view, name="side_bar"),
     path('info/', plugin_info_view, name="plugin_info"),
     path('ping/', ping_view, name="ping"),

--- a/calendar_backend/calendarapp/views.py
+++ b/calendar_backend/calendarapp/views.py
@@ -163,6 +163,40 @@ def event_list(request):
 # }
 
 
+'''
+event detail view with a list of event-specific reminder(s) previously 
+set by a particular user.
+'''
+@api_view(['GET'])
+def event_detail_view(request, id):
+    plugin_id = PLUGIN_ID
+    organization_id = ORGANIZATION_ID
+
+    if request.method == 'GET':
+        url_event = f'https://api.zuri.chat/data/read/{plugin_id}/event/{organization_id}?_id={id}'
+        
+        try:
+            response_event = requests.get(url=url_event)
+
+            if response_event.status_code == 200:
+                event_data = response_event.json()['data']
+
+                # to retrieve reminder(s) for this particular event
+                # that belongs to the current user.
+
+
+
+                # adding the user-specific event reminder(s) to the event.
+                event_data['reminders'] = reminder_data
+                return Response(event_data, status=status.HTTP_200_OK)
+            else:
+                return Response({'error': response_event.json()['message']}, status=response_event.status_code)
+
+        except exceptions.ConnectionError as e:
+            return Response(str(e), status=status.HTTP_502_BAD_GATEWAY)
+
+
+
 class CreateReminderView(generics.GenericAPIView):
     serializer_class = ReminderSerializer
 


### PR DESCRIPTION
Retrieving the list of reminder(s) a particular user had previously created would be done in this view by @Vicolas11. Thus, the output of this view would be like:

{
    "_id": "61425dd49fd1f4f655d4463c",
    "all_day": true,
    "description": "aaa",
    "end_date": "2021-09-30",
    "end_time": "02:55:00",
    "event_colour": "aaa",
    "event_tag": "aaa",
    "event_title": "test",
    "start_date": "2021-09-17",
    "start_time": "21:55:00",
    "time_zone": "Africa/Abidjan",
    "reminders": [
        {
            "_id": "6143a64fd0284bc6a922363d",
            "date": "2021-08-31",
            "event_id": "61425dd49fd1f4f655d4463c",
            "time": "22:17:00",
            "user_id": "613caf3fceee2ab59d44df06",
            ...
        }
    ]
}

solved issue #368 